### PR TITLE
Add configuration capability for Spark master/worker nodes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,11 @@ ADD port-forward.sh /opt/port-forward.sh
 ADD connect-to-jobs-ui.sh /opt/connect-to-jobs-ui.sh
 ADD sanity_check.ipynb /opt/sanity_check.ipynb
 
+# Spark cluster configuration can be modified via 
+#    spark-cluster-configuration-profile.sh (see README.md for defaults)
+RUN mkdir /etc/datahub-profile.d
+ADD spark-cluster-configuration-profile.sh /etc/datahub-profile.d
+
 RUN chmod 777  /opt/*.sh /opt/*.ipynb
 
 ENV SPARK_CHART_NAME=spark

--- a/README.md
+++ b/README.md
@@ -7,3 +7,46 @@ Must be developed on dsmlp-login as it's coupled to that system
 ## Architecture
 
 `start-cluster.sh` and `stop-cluster.sh` are meant to run as kubernetes lifecycle hooks to start and stop the cluster as the pod starts
+
+## Cluster Configuration
+
+The cluster and master/worker nodes may be configured via the following environment variables.
+
+SPARK_CHART_NAME
+: Helm chart used to instantiate Spark cluster
+: Default =
+
+SPARK_CLUSTER_IMAGE_REGISTRY
+: Default = ghcr.io
+SPARK_CLUSTER_IMAGE_REPO ucsd-ets/spark-node
+: Default = ucsd-ets/spark-node
+SPARK_CLUSTER_IMAGE_TAG
+: Default = fa22-3
+
+SPARK_CLUSTER_MASTER_CPU
+: Number of CPU cores assigned to Master node (sets kubernetes request&limit)
+: Default = 2
+SPARK_CLUSTER_MASTER_MEM
+: Memory assigned to Master node (sets kubernetes request&limit)
+: Default = 8G
+
+SPARK_CLUSTER_WORKER_CPU
+: Number of CPU cores assigned to Worker nodes (sets kubernetes request&limit)
+: Default = 2
+SPARK_CLUSTER_WORKER_MEM
+: Memory assigned to Worker node (sets kubernetes request&limit)
+: Default = 20G
+SPARK_CLUSTER_WORKER_APP_MEM
+: Spark application memory limit (should be ~2GB less than WORKER_MEM)
+: Default = 18G
+SPARK_CLUSTER_REPLICAS
+: Number of worker nodes to start up
+: Default = 3
+
+SPARK_CLUSTER_RUNASGROUP 
+: Primary Unix group ID assigned to cluster nodes
+: Default value: 0
+SPARK_CLUSTER_FSGROUP 
+: Supplemental Unix group ID assigned to cluster nodes
+: Default value: 0
+

--- a/spark-cluster-configuration-profile.sh
+++ b/spark-cluster-configuration-profile.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# automatically export env variables
+set -A
+
+# Use this file to override default Spark cluster configuration set by '/opt/start-cluster.sh'
+# e.g.
+
+SPARK_CLUSTER_REPLICAS=3
+
+# Permit individual per-user overrides
+[ -f ~/.spark-cluster-configuration-profile.sh ] && . ~/.spark-cluster-configuration-profile.sh
+

--- a/start-cluster.sh
+++ b/start-cluster.sh
@@ -6,32 +6,32 @@ WORKSPACE=$(dirname $HOMEMOUNT)
 WORKSPACE=$(dirname $WORKSPACE)
 
 helm install $SPARK_CHART_NAME /opt/spark \
-    --set image.registry=ghcr.io \
-    --set image.repository=ucsd-ets/spark-node \
-    --set image.tag=fa22-3 \
+    --set image.registry=${SPARK_CLUSTER_IMAGE_REGISTRY:-ghcr.io} \
+    --set image.repository=${SPARK_CLUSTER_IMAGE_REPO:-ucsd-ets/spark-node} \
+    --set image.tag=${SPARK_CLUSTER_IMAGE_TAG:-fa22-3} \
     --set image.pullPolicy=Always \
     --set serviceAccount.name=default \
     --set serviceAccount.create=false \
     --set master.podSecurityContext.runAsUser=$UID \
     --set master.containerSecurityContext.runAsUser=$UID \
-    --set worker.replicaCount=3 \
+    --set worker.replicaCount=${SPARK_CLUSTER_REPLICAS:-3} \
     --set worker.podSecurityContext.runAsUser=$UID \
     --set worker.containerSecurityContext.runAsUser=$UID \
-    --set master.podSecurityContext.runAsGroup=0 \
-    --set master.podSecurityContext.fsGroup=0 \
-    --set worker.podSecurityContext.runAsGroup=0 \
-    --set worker.podSecurityContext.fsGroup=0 \
-    --set worker.resources.requests.memory=20G \
-    --set worker.resources.limits.memory=20G \
-    --set worker.coreLimit=2 \
-    --set worker.resources.limits.cpu=2 \
-    --set worker.resources.requests.cpu=2 \
-    --set master.resources.limits.cpu=2 \
-    --set master.resources.requests.cpu=2 \
-    --set master.resources.limits.memory=8G \
-    --set master.resources.requests.memory=8G \
-    --set master.memoryLimit=8G \
-    --set worker.memoryLimit=18G \
+    --set master.podSecurityContext.runAsGroup=${SPARK_CLUSTER_RUNASGROUP:-0} \
+    --set master.podSecurityContext.fsGroup=${SPARK_CLUSTER_FSGROUP:-0} \
+    --set worker.podSecurityContext.runAsGroup=${SPARK_CLUSTER_RUNASGROUP:-0} \
+    --set worker.podSecurityContext.fsGroup=${SPARK_CLUSTER_FSGROUP:-0} \
+    --set worker.resources.requests.memory=${SPARK_CLUSTER_WORKER_MEM:-20G} \
+    --set worker.resources.limits.memory=${SPARK_CLUSTER_WORKER_MEM:-20G} \
+    --set worker.coreLimit=${SPARK_CLUSTER_WORKER_CPU:-2} \
+    --set worker.resources.limits.cpu=${SPARK_CLUSTER_WORKER_CPU:-2} \
+    --set worker.resources.requests.cpu=${SPARK_CLUSTER_WORKER_CPU:-2} \
+    --set master.resources.limits.cpu=${SPARK_CLUSTER_MASTER_CPU:-2} \
+    --set master.resources.requests.cpu=${SPARK_CLUSTER_MASTER_CPU:-2} \
+    --set master.resources.limits.memory=${SPARK_CLUSTER_MASTER_MEM:-8G} \
+    --set master.resources.requests.memory=${SPARK_CLUSTER_MASTER_MEM:-8G} \
+    --set master.memoryLimit=${SPARK_CLUSTER_MASTER_MEM:-8G} \
+    --set worker.memoryLimit=${SPARK_CLUSTER_WORKER_APP_MEM:-18G} \
     --set-json="worker.extraVolumes[0]={\"name\":\"course-workspace\",\"nfs\":{\"server\":\"${FILESYSTEM}\",\"path\":\"${WORKSPACE}\"}}" \
     --set-json='worker.extraVolumes[1]={"name":"home","persistentVolumeClaim":{"claimName":"home"}}' \
     --set-json='worker.extraVolumeMounts[0]={"name":"course-workspace","mountPath":"/home/${USER}"}' \


### PR DESCRIPTION

Options are set by way of Environment variables, which could be set by OPA (in the future), within '/etc/datahub-profile.d/spark-cluster-configuration-profile.sh' file, or within a user-editable file under their home directory:'~/.spark-cluster-configuration-profile.sh' sourced by the version in /etc/datahub-profile.d'